### PR TITLE
fix: resolve React key duplicates and asChild prop warning

### DIFF
--- a/components/journey.tsx
+++ b/components/journey.tsx
@@ -187,7 +187,7 @@ export default function Journey() {
             </div>
             <div className="space-y-8">
               {education.map((item, index) => (
-                <TimelineItem key={item.school} item={item} index={index} type="education" />
+                <TimelineItem key={`${item.school}-${index}`} item={item} index={index} type="education" />
               ))}
             </div>
           </div>
@@ -202,7 +202,7 @@ export default function Journey() {
             </div>
             <div className="space-y-8">
               {experience.map((item, index) => (
-                <TimelineItem key={item.company} item={item} index={index} type="experience" />
+                <TimelineItem key={`${item.company}-${index}`} item={item} index={index} type="experience" />
               ))}
             </div>
           </div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -41,7 +41,7 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
     return (
       <button
         className={cn(buttonVariants({ variant, size, className }))}


### PR DESCRIPTION
- Fix duplicate React keys in journey.tsx by using compound keys (company/school + index)
- Extract asChild prop in button.tsx to prevent prop spreading warning
- Verified all 3D dependencies are properly installed
- Build completes successfully with no errors