### PR TITLE
fix: add mobile detection and simplify animations for iOS Safari

### DIFF
--- a/components/sections/ContactCanvas.tsx
+++ b/components/sections/ContactCanvas.tsx
@@ -9,32 +9,38 @@ const SPARKLE_POSITIONS = [
   { left: 85, top: 55 }, { left: 25, top: 85 }, { left: 60, top: 15 },
 ];
 
+// Static version - safe for all devices
+function StaticGear() {
+  return (
+    <div className="w-full h-full relative overflow-hidden bg-gradient-to-br from-gray-800/50 to-gray-900/50 rounded-lg">
+      <div className="absolute inset-0 flex items-center justify-center">
+        <svg className="w-20 h-20 text-cyan-400/40" viewBox="0 0 100 100" fill="currentColor">
+          <path d="M50 30a20 20 0 100 40 20 20 0 000-40zm0 30a10 10 0 110-20 10 10 0 010 20z" />
+          {[...Array(10)].map((_, i) => (
+            <rect key={i} x="46" y="5" width="8" height="12" rx="2" transform={`rotate(${i * 36} 50 50)`} />
+          ))}
+        </svg>
+      </div>
+    </div>
+  );
+}
+
 export default function ContactCanvas() {
   const [mounted, setMounted] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(true); // Default to mobile (safe)
 
   useEffect(() => {
+    const mobile = isMobileDevice();
+    setIsMobile(mobile);
     setMounted(true);
-    setIsMobile(isMobileDevice());
   }, []);
 
-  // Mobile: simplified static version
-  if (mounted && isMobile) {
-    return (
-      <div className="w-full h-full relative overflow-hidden bg-gradient-to-br from-gray-800/50 to-gray-900/50 rounded-lg">
-        <div className="absolute inset-0 flex items-center justify-center">
-          <svg className="w-20 h-20 text-cyan-400/40" viewBox="0 0 100 100" fill="currentColor">
-            <path d="M50 30a20 20 0 100 40 20 20 0 000-40zm0 30a10 10 0 110-20 10 10 0 010 20z" />
-            {[...Array(10)].map((_, i) => (
-              <rect key={i} x="46" y="5" width="8" height="12" rx="2" transform={`rotate(${i * 36} 50 50)`} />
-            ))}
-          </svg>
-        </div>
-      </div>
-    );
+  // Before mount OR on mobile: show static safe version
+  if (!mounted || isMobile) {
+    return <StaticGear />;
   }
 
-  // Desktop: full animated version
+  // Desktop only: full animated version
   return (
     <div className="w-full h-full relative overflow-hidden bg-gradient-to-br from-gray-800/50 to-gray-900/50 rounded-lg">
       <div className="absolute top-1/4 left-1/4 w-24 h-24 bg-cyan-500/20 rounded-full blur-2xl animate-float-slow" />
@@ -65,7 +71,7 @@ export default function ContactCanvas() {
         </div>
       </div>
 
-      {mounted && SPARKLE_POSITIONS.map((pos, i) => (
+      {SPARKLE_POSITIONS.map((pos, i) => (
         <div
           key={i}
           className="absolute w-1 h-1 bg-cyan-400/60 rounded-full animate-twinkle"

--- a/components/sections/HeroCanvas.tsx
+++ b/components/sections/HeroCanvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { isMobileDevice } from '@/lib/utils';
 
 // Fixed particle positions to avoid hydration mismatch
@@ -11,59 +11,66 @@ const PARTICLE_POSITIONS = [
   { left: 75, top: 90 }, { left: 5, top: 40 }, { left: 60, top: 70 },
 ];
 
+// Static background - safe for all devices, no blur, no animations
+function StaticBackground() {
+  return (
+    <div className="w-full h-full relative overflow-hidden bg-gradient-to-b from-gray-900 via-gray-900 to-background">
+      {/* Simple gradient - no blur, no animations */}
+      <div className="absolute inset-0 opacity-40">
+        <div className="absolute inset-0 bg-gradient-to-br from-cyan-500/30 via-blue-500/20 to-purple-500/30" />
+      </div>
+
+      {/* Static grid pattern */}
+      <div
+        className="absolute inset-0 opacity-10"
+        style={{
+          backgroundImage: `
+            linear-gradient(rgba(0, 212, 255, 0.1) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(0, 212, 255, 0.1) 1px, transparent 1px)
+          `,
+          backgroundSize: '50px 50px',
+        }}
+      />
+
+      {/* Simple center glow - no blur filter */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="w-48 h-48 bg-gradient-to-br from-cyan-400/20 to-blue-500/20 rounded-full" />
+      </div>
+
+      {/* Static gear icon */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <svg
+          className="w-16 h-16 text-cyan-400/50"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
+          <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z" />
+        </svg>
+      </div>
+    </div>
+  );
+}
+
 export default function HeroCanvas() {
   const [mounted, setMounted] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(true); // Default to mobile (safe)
 
   useEffect(() => {
+    const mobile = isMobileDevice();
+    setIsMobile(mobile);
     setMounted(true);
-    setIsMobile(isMobileDevice());
   }, []);
 
-  // Mobile: simplified static background
-  if (mounted && isMobile) {
-    return (
-      <div className="w-full h-full relative overflow-hidden bg-gradient-to-b from-gray-900 via-gray-900 to-background">
-        {/* Simple gradient - no blur, no animations */}
-        <div className="absolute inset-0 opacity-40">
-          <div className="absolute inset-0 bg-gradient-to-br from-cyan-500/30 via-blue-500/20 to-purple-500/30" />
-        </div>
-
-        {/* Static grid pattern */}
-        <div
-          className="absolute inset-0 opacity-10"
-          style={{
-            backgroundImage: `
-              linear-gradient(rgba(0, 212, 255, 0.1) 1px, transparent 1px),
-              linear-gradient(90deg, rgba(0, 212, 255, 0.1) 1px, transparent 1px)
-            `,
-            backgroundSize: '50px 50px',
-          }}
-        />
-
-        {/* Simple center glow - no blur filter */}
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="w-48 h-48 bg-gradient-to-br from-cyan-400/20 to-blue-500/20 rounded-full" />
-        </div>
-
-        {/* Static gear icon */}
-        <div className="absolute inset-0 flex items-center justify-center">
-          <svg
-            className="w-16 h-16 text-cyan-400/50"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-          >
-            <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
-            <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z" />
-          </svg>
-        </div>
-      </div>
-    );
+  // Before mount OR on mobile: show static safe version
+  // This prevents iOS Safari crash on initial render
+  if (!mounted || isMobile) {
+    return <StaticBackground />;
   }
 
-  // Desktop: full animated experience
+  // Desktop only: full animated experience (only after confirming NOT mobile)
   return (
     <div className="w-full h-full relative overflow-hidden bg-gradient-to-b from-gray-900 via-gray-900 to-background">
       {/* Animated gradient background */}
@@ -88,37 +95,35 @@ export default function HeroCanvas() {
         }}
       />
 
-      {/* Animated rings - desktop only */}
-      {mounted && (
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="relative">
-            <div className="absolute -inset-32 border border-cyan-500/20 rounded-full animate-spin-slow" />
-            <div className="absolute -inset-24 border border-blue-500/20 rounded-full animate-spin-reverse" />
-            <div className="absolute -inset-16 border border-cyan-400/30 rounded-full animate-spin-slow" />
+      {/* Animated rings */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="relative">
+          <div className="absolute -inset-32 border border-cyan-500/20 rounded-full animate-spin-slow" />
+          <div className="absolute -inset-24 border border-blue-500/20 rounded-full animate-spin-reverse" />
+          <div className="absolute -inset-16 border border-cyan-400/30 rounded-full animate-spin-slow" />
 
-            {/* Center glow */}
-            <div className="w-32 h-32 bg-gradient-to-br from-cyan-400/40 to-blue-500/40 rounded-full blur-xl animate-pulse-glow" />
+          {/* Center glow */}
+          <div className="w-32 h-32 bg-gradient-to-br from-cyan-400/40 to-blue-500/40 rounded-full blur-xl animate-pulse-glow" />
 
-            {/* Gear icon */}
-            <div className="absolute inset-0 flex items-center justify-center">
-              <svg
-                className="w-16 h-16 text-cyan-400/60 animate-spin-very-slow"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-              >
-                <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
-                <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z" />
-              </svg>
-            </div>
+          {/* Gear icon */}
+          <div className="absolute inset-0 flex items-center justify-center">
+            <svg
+              className="w-16 h-16 text-cyan-400/60 animate-spin-very-slow"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            >
+              <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
+              <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z" />
+            </svg>
           </div>
         </div>
-      )}
+      </div>
 
-      {/* Floating particles - fixed positions, desktop only */}
+      {/* Floating particles - fixed positions */}
       <div className="absolute inset-0 overflow-hidden">
-        {mounted && PARTICLE_POSITIONS.map((pos, i) => (
+        {PARTICLE_POSITIONS.map((pos, i) => (
           <div
             key={i}
             className="absolute w-1 h-1 bg-cyan-400/40 rounded-full animate-float-particle"

--- a/components/sections/SkillsCanvas.tsx
+++ b/components/sections/SkillsCanvas.tsx
@@ -3,36 +3,38 @@
 import { useEffect, useState } from 'react';
 import { isMobileDevice } from '@/lib/utils';
 
+// Static version - safe for all devices
+function StaticGear() {
+  return (
+    <div className="w-full h-full min-h-[300px] relative overflow-hidden bg-gradient-to-br from-gray-800/50 to-gray-900/50 rounded-lg">
+      <div className="absolute inset-0 flex items-center justify-center">
+        <svg className="w-24 h-24 text-cyan-400/40" viewBox="0 0 100 100" fill="currentColor">
+          <path d="M50 30a20 20 0 100 40 20 20 0 000-40zm0 30a10 10 0 110-20 10 10 0 010 20z" />
+          {[...Array(8)].map((_, i) => (
+            <rect key={i} x="46" y="5" width="8" height="15" rx="2" transform={`rotate(${i * 45} 50 50)`} />
+          ))}
+        </svg>
+      </div>
+    </div>
+  );
+}
+
 export default function SkillsCanvas() {
   const [mounted, setMounted] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(true); // Default to mobile (safe)
 
   useEffect(() => {
+    const mobile = isMobileDevice();
+    setIsMobile(mobile);
     setMounted(true);
-    setIsMobile(isMobileDevice());
   }, []);
 
-  // Mobile: simplified static version
-  if (mounted && isMobile) {
-    return (
-      <div className="w-full h-full min-h-[300px] relative overflow-hidden bg-gradient-to-br from-gray-800/50 to-gray-900/50 rounded-lg">
-        <div className="absolute inset-0 flex items-center justify-center">
-          <svg
-            className="w-24 h-24 text-cyan-400/40"
-            viewBox="0 0 100 100"
-            fill="currentColor"
-          >
-            <path d="M50 30a20 20 0 100 40 20 20 0 000-40zm0 30a10 10 0 110-20 10 10 0 010 20z" />
-            {[...Array(8)].map((_, i) => (
-              <rect key={i} x="46" y="5" width="8" height="15" rx="2" transform={`rotate(${i * 45} 50 50)`} />
-            ))}
-          </svg>
-        </div>
-      </div>
-    );
+  // Before mount OR on mobile: show static safe version
+  if (!mounted || isMobile) {
+    return <StaticGear />;
   }
 
-  // Desktop: full animated version
+  // Desktop only: full animated version
   return (
     <div className="w-full h-full min-h-[300px] relative overflow-hidden bg-gradient-to-br from-gray-800/50 to-gray-900/50 rounded-lg">
       <div className="absolute inset-0 flex items-center justify-center">
@@ -60,20 +62,18 @@ export default function SkillsCanvas() {
 
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-40 h-40 bg-cyan-500/10 rounded-full blur-3xl animate-pulse" />
 
-      {mounted && (
-        <svg className="absolute inset-0 w-full h-full opacity-20">
-          <defs>
-            <linearGradient id="circuit-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-              <stop offset="0%" stopColor="#00d4ff" stopOpacity="0" />
-              <stop offset="50%" stopColor="#00d4ff" stopOpacity="1" />
-              <stop offset="100%" stopColor="#00d4ff" stopOpacity="0" />
-            </linearGradient>
-          </defs>
-          <line x1="0" y1="30%" x2="30%" y2="30%" stroke="url(#circuit-gradient)" strokeWidth="1" className="animate-circuit-1" />
-          <line x1="70%" y1="70%" x2="100%" y2="70%" stroke="url(#circuit-gradient)" strokeWidth="1" className="animate-circuit-2" />
-          <line x1="20%" y1="0" x2="20%" y2="25%" stroke="url(#circuit-gradient)" strokeWidth="1" className="animate-circuit-3" />
-        </svg>
-      )}
+      <svg className="absolute inset-0 w-full h-full opacity-20">
+        <defs>
+          <linearGradient id="circuit-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#00d4ff" stopOpacity="0" />
+            <stop offset="50%" stopColor="#00d4ff" stopOpacity="1" />
+            <stop offset="100%" stopColor="#00d4ff" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <line x1="0" y1="30%" x2="30%" y2="30%" stroke="url(#circuit-gradient)" strokeWidth="1" className="animate-circuit-1" />
+        <line x1="70%" y1="70%" x2="100%" y2="70%" stroke="url(#circuit-gradient)" strokeWidth="1" className="animate-circuit-2" />
+        <line x1="20%" y1="0" x2="20%" y2="25%" stroke="url(#circuit-gradient)" strokeWidth="1" className="animate-circuit-3" />
+      </svg>
     </div>
   );
 }


### PR DESCRIPTION
Key fix: Default to mobile (safe) mode on initial render, only upgrade to desktop animations AFTER confirming NOT mobile.

Previous logic was broken because:
- isMobile defaulted to false
- Before useEffect ran, desktop version with blur-3xl rendered
- iOS Safari crashed on initial render BEFORE mobile check could run

New logic:
- isMobile defaults to true (safe assumption)
- Show static fallback on initial render AND on mobile
- Only show animated desktop version after mount confirms NOT mobile

Changes:
- HeroCanvas: Static fallback component, safe-first rendering
- SkillsCanvas: Static fallback component, safe-first rendering
- ContactCanvas: Static fallback component, safe-first rendering